### PR TITLE
enable comments

### DIFF
--- a/_posts/2020-03-02-kubeflow-1-0-cloud-native-ml-for-everyone.md
+++ b/_posts/2020-03-02-kubeflow-1-0-cloud-native-ml-for-everyone.md
@@ -2,6 +2,7 @@
 toc: true
 layout: post
 categories: [releases]
+comments: true
 title: Kubeflow 1.0 - Cloud Native ML for Everyone
 author: Thea Lamkin (Google), Jeremy Lewi (Google), Josh Bottum (Arrikto), Elvira Dzhuraeva (Cisco), David Aronchick (Microsoft), Amy Unruh (Google), Animesh Singh (IBM), and Ellis Bigelow (Google).
 ---

--- a/_posts/2020-03-16-mpi-operator.md
+++ b/_posts/2020-03-16-mpi-operator.md
@@ -3,6 +3,7 @@ toc: true
 layout: post
 categories: [integrations, operators]
 title: Introduction to Kubeflow MPI Operator and Industry Adoption
+comments: true
 author: "<a href='https://twitter.com/TerryTangYuan'>Yuan Tang</a> (Ant Financial), <a href='https://www.linkedin.com/in/wei-yan-a6037337'>Wei Yan</a> (Ant Financial), and <a href='https://www.linkedin.com/in/rongou'>Rong Ou</a> (NVIDIA)"
 ---
 

--- a/_posts/2020-07-10-kubeflow-kale.md
+++ b/_posts/2020-07-10-kubeflow-kale.md
@@ -3,6 +3,7 @@ toc: true
 layout: post
 categories: [integrations]
 description: Running pipelines at scale has never been easier.
+comments: true
 title: Kubeflow & Kale simplify building better ML Pipelines with automatic hyperparameter tuning
 author: Stefano Fioravanzo
 ---


### PR DESCRIPTION
Fastpages has the ability enable comments on blog posts, natively through GitHub issues.  

This is enabled through the front matter

`comments: true`

cc: @jlewi 