### PR TITLE
add dependabot config script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+updates:
+- assignees:
+  - kramachandran
+  directory: _action_files
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  schedule:
+    interval: daily
+- assignees:
+  - kramachandran
+  directory: .
+  open-pull-requests-limit: 10
+  package-ecosystem: bundler
+  schedule:
+    interval: daily
+version: 2

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,6 @@ restart-jekyll: .FORCE
 	docker-compose restart jekyll
 
 .FORCE:
+
+build-dependabot:
+	python3 hack/create_dependabot.py

--- a/hack/create_dependabot.py
+++ b/hack/create_dependabot.py
@@ -1,0 +1,116 @@
+import yaml
+import collections
+from pathlib import Path
+
+dependabot = {}
+dependabot['version'] = 2
+dependabot['updates'] = []
+ignored_folders = ['node_modules', 'dist', '.git', 'deprecated']
+
+def get_owners(path):
+    while not Path(path/'OWNERS').is_file():
+        path = path.parent.absolute()
+    with open(path/'OWNERS') as owner_file:
+        owners = yaml.load(owner_file)
+        return owners
+
+def get_docker_paths():
+    dockerfile_list = list(repo_path.glob('**/*ockerfile*'))
+    docker_clean_list = []
+    for dockerfile in dockerfile_list:
+        if all(x not in str(dockerfile) for x in ignored_folders):
+            if dockerfile.parents[0] not in docker_clean_list:
+                docker_clean_list.append(dockerfile.parents[0])
+    return docker_clean_list
+
+def get_npm_paths():
+    npm_list = list(repo_path.glob('**/package*.json'))
+    npm_clean_list = []
+    for npm_file in npm_list:
+        if all(x not in str(npm_file) for x in ignored_folders):
+            if npm_file.parents[0] not in npm_clean_list:
+                npm_clean_list.append(npm_file.parents[0])
+    return npm_clean_list
+
+def get_pip_paths():
+    pip_list = list(repo_path.glob('**/*requirements.txt'))
+    pip_clean_list = []
+    for pip_file in pip_list:
+        if all(x not in str(pip_file) for x in ignored_folders):
+            if pip_file.parents[0] not in pip_clean_list:
+                pip_clean_list.append(pip_file.parents[0])
+    return pip_clean_list
+
+def get_go_paths():
+    go_list = list(repo_path.glob('**/go.*'))
+    go_clean_list = []
+    for go_file in go_list:
+        if all(x not in str(go_file) for x in ignored_folders):
+            if go_file.parents[0] not in go_clean_list:
+                go_clean_list.append(go_file.parents[0])
+    return go_clean_list
+
+def get_ruby_paths():
+    ruby_list = list(repo_path.glob('**/Gemfile*'))
+    ruby_clean_list = []
+    for ruby_file in ruby_list:
+        if all(x not in str(ruby_file) for x in ignored_folders):
+            if ruby_file.parents[0] not in ruby_clean_list:
+                ruby_clean_list.append(ruby_file.parents[0])
+    return ruby_clean_list
+
+def append_updates(ecosystem, directory, assignees, reviewers=None):
+    config = {}
+    config['package-ecosystem'] = ecosystem
+    config['directory'] = directory
+    config['schedule']= {}
+    config['schedule']['interval'] = 'daily'
+    config['open-pull-requests-limit'] = 10
+    config['assignees'] = assignees
+    if reviewers:
+        config['reviewers'] = reviewers
+    dependabot['updates'].append(config)
+
+def main():
+    for docker_path in get_docker_paths():
+        string_path = str(docker_path)
+        assignees = get_owners(docker_path).get('approvers')
+        reviewers = get_owners(docker_path).get('reviewers')
+        append_updates('docker', string_path, assignees, reviewers)
+
+    for npm_path in get_npm_paths():
+        string_path = str(npm_path)
+        assignees = get_owners(npm_path).get('approvers')
+        reviewers = get_owners(npm_path).get('reviewers')
+        append_updates('npm', string_path, assignees, reviewers)
+
+    for pip_path in get_pip_paths():
+        string_path = str(pip_path)
+        assignees = get_owners(pip_path).get('approvers')
+        reviewers = get_owners(pip_path).get('reviewers')
+        append_updates('pip', string_path, assignees, reviewers)
+
+    for go_path in get_go_paths():
+        string_path = str(go_path)
+        assignees = get_owners(go_path).get('approvers')
+        reviewers = get_owners(go_path).get('reviewers')
+        append_updates('gomod', string_path, assignees, reviewers)
+
+    for ruby_path in get_ruby_paths():
+        string_path = str(ruby_path)
+        assignees = get_owners(ruby_path).get('approvers')
+        reviewers = get_owners(ruby_path).get('reviewers')
+        append_updates('bundler', string_path, assignees, reviewers)
+
+    with open('.github/dependabot.yml', 'w') as outfile:
+        yaml.dump(dependabot, outfile, default_flow_style=False)
+
+    print(get_docker_paths())
+    print(get_npm_paths())
+    print(get_pip_paths())
+    print(get_go_paths())
+    print(get_ruby_paths())
+
+if __name__ == "__main__":
+    repo_path = Path(__file__).parents[1]
+    main()


### PR DESCRIPTION
Inspired by https://github.com/kubeflow/pipelines/issues/4682  I created a script that will create a config file for depandabot so that it knows what directories to scan. It will scan the repository for files named `*ockerfile*`, `package*.json`, `*requirements.txt`, `go.*` and `Gemfile*`.  It is setup for dockerfiles, npm packages, pip, ruby and gomod dependencies at the moment. It is trivial to further customize what folders are selected if further customization is needed. It also parses the closest `OWNERS` file for a given dependency listing file, and assigns the relevant approvers and adds the relevant reviewers to the PRs it creates. 

This is a sibling PR to https://github.com/kubeflow/pipelines/pull/5015, https://github.com/kubeflow/kubeflow/pull/5542, https://github.com/kubeflow/kfserving/pull/1309, https://github.com/kubeflow/arena/pull/403, https://github.com/kubeflow/testing/pull/855, https://github.com/kubeflow/fairing/pull/550, https://github.com/kubeflow/kfp-tekton/pull/432, https://github.com/kubeflow/katib/pull/1420, https://github.com/kubeflow/tf-operator/pull/1224, https://github.com/kubeflow/kfp-tekton-backend/pull/28, https://github.com/kubeflow/mpi-operator/pull/319, https://github.com/kubeflow/pytorch-operator/pull/315, https://github.com/kubeflow/metadata/pull/255, https://github.com/kubeflow/xgboost-operator/pull/107, https://github.com/kubeflow/fate-operator/pull/26, https://github.com/kubeflow/mxnet-operator/pull/87, https://github.com/kubeflow/website/pull/2459, https://github.com/kubeflow/kfctl/pull/479, https://github.com/kubeflow/examples/pull/843, https://github.com/kubeflow/code-intelligence/pull/198, https://github.com/kubeflow/gcp-blueprints/pull/192 and https://github.com/kubeflow/common/pull/107.

As it stands now, there will be about 11 PRs that will be created with this configuration.

For reference, the PRs that will be created can be found here: https://github.com/DavidSpek/blog/pulls