### PR TITLE
Fix links in Katib blog

### DIFF
--- a/_posts/2021-03-10-katib-0.10.md
+++ b/_posts/2021-03-10-katib-0.10.md
@@ -141,7 +141,7 @@ to know more about CRDs.
 Follow these two simple steps to integrate new CRD in Katib:
 
 1. Modify
-   the Katib controller [Deployment's arguments](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/katib-controller/katib-controller.yaml#L26)
+   the Katib controller [Deployment's arguments](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/controller/controller.yaml#L26)
    with the new flag:
 
    ```
@@ -167,7 +167,7 @@ Follow these two simple steps to integrate new CRD in Katib:
    ```
 
 2. Modify the Katib controller
-   [ClusterRole's rules](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/katib-controller/rbac.yaml#L5)
+   [ClusterRole's rules](https://github.com/kubeflow/katib/blob/master/manifests/v1beta1/components/controller/rbac.yaml#L5)
    with the new rule to give Katib an access to all Kubernetes resources that
    are created by the CRD's controller. To know more about ClusterRole,
    please check the [Kubernetes guide](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).


### PR DESCRIPTION
After this PR: https://github.com/kubeflow/katib/pull/1464 some links have been changed.

/assign @theadactyl @Bobgy @kramachandran @james-jwu
/cc @gaocegege @johnugeorge 