### PR TITLE
Change permalink for 1.5.1 blogpost to avoid conflict

### DIFF
--- a/_posts/2022-07-18-kubeflow-1.5.1-release.md
+++ b/_posts/2022-07-18-kubeflow-1.5.1-release.md
@@ -6,7 +6,7 @@ comments: true
 image: images/logo.png
 hide: false
 categories: [release]
-permalink: /kubeflow-1.5-release/
+permalink: /kubeflow-1.5.1-release/
 author: "Kubeflow 1.5 Release Team"
 ---
 


### PR DESCRIPTION
Currently it is conflicting with https://blog.kubeflow.org/kubeflow-1.5-release/