### PR TITLE
Update KServe stats to include KFServing

### DIFF
--- a/_posts/2022-08-19-kubeflow-user-survey-2022.md
+++ b/_posts/2022-08-19-kubeflow-user-survey-2022.md
@@ -17,7 +17,7 @@ The survey was comprised of 24 questions (multiple choice and freeform). It ran 
 ## Key Takeaways
 
 - 85% of the users deploy more than one Kubeflow component
-- The top 3 Kubeflow components are Pipelines (89%), Notebooks (75%), and KServe (48%)
+- The top 3 Kubeflow components are Pipelines (89%), KServe(Formally KFServing) (81%), Notebooks (75%).
 - Data preprocessing and transformations are the most challenging (44%) and time-consuming (73%) steps in the ML lifecycle
 - 59% of the users identify model monitoring as the biggest gap in their ML lifecycle and 32% of the users identify model monitoring as the most challenging
 - 44% of the users are running Kubeflow in production


### PR DESCRIPTION
According to [original survey results slide 23](https://15905978862850875460.googlegroups.com/attach/150ca032927e6/'22%20Kubeflow%201.6%20User%20Survey%20-%20initial%20results.pdf?part=0.1.1&view=1&view=1&vt=ANaJVrEpz65q1fiTBBTJPdha6ISn8FPrZgN58-eaZs8OodRbyhfH4yOq-R_9CL803CQTiVXne1z6YmpYW6CGSa0q8GzqS6Sgj3RAsGfbx53XVvwFqG7lVW0) **33.3%** of users are on KFServing and **48.3%** of users are on KServe, KServe/KFServing is basically the same component so when talking about stats we should really combine them.