### PR TITLE
Add KSC members to approvers in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 approvers:
-- james-jwu
-- kramachandran
-- theadactyl
-- zijianjoy
-reviewers:
-- zijianjoy
+  - andreyvelich
+  - james-jwu
+  - jbottum
+  - johnugeorge
+  - terrytangyuan
+  - zijianjoy


### PR DESCRIPTION
Same as https://github.com/kubeflow/internal-acls/pull/652.

cc @kubeflow/kubeflow-steering-committee 