### PR TITLE
chore: remove unnecessary primer.css conflicting with minima theme

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -7,7 +7,7 @@
 
 
 {%- include favicons.html -%}
-<link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" />
+<!-- remove conflicting design language, especially for unvisited links: <link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" /> -->
 <link rel="stylesheet" href="//use.fontawesome.com/releases/v5.0.7/css/all.css">
 
 {%- if site.annotations -%}


### PR DESCRIPTION
It seems to me use of primer.css (GitHub default's design system) conflicts with this blog's theme ("minima" customized) in some places, but most importantly unvisited links.

This result in being unable to distinguish in a blog post which are the available links (common in websites). Examples will be provided down below.

This PR proposes to remove primer.css imports to avoid said conflicts.
This PR is continued from: https://github.com/kubeflow/blog/pull/150#issuecomment-2220198719

cc @StefanoFioravanzo @rimolive @juliusvonkohout wdyt?

## Examples today **Vs** this_pr

![Screenshot 2024-07-25 at 10 48 44 (2)](https://github.com/user-attachments/assets/4a613cc5-184f-4d63-9a2a-adade9c98c00)

![Screenshot 2024-07-25 at 10 48 22 (2)](https://github.com/user-attachments/assets/abf13664-5743-4905-b4e4-053f7935bdad)

as can be seen in Netlify preview in the action runs below.