### PR TITLE
Remove redundant blog post title from the fraud detection article

### DIFF
--- a/_posts/2025-07-15-fraud-detection-e2e.md
+++ b/_posts/2025-07-15-fraud-detection-e2e.md
@@ -10,8 +10,6 @@ permalink: /fraud-detection-e2e/
 author: "Helber Belmiro"
 ---
 
-# From Raw Data to Model Serving: A Blueprint for the AI/ML Lifecycle with Kubeflow
-
 Are you looking for a practical, reproducible way to take a machine learning project from raw data all the way to a deployed, production-ready model? This post is your blueprint for the AI/ML lifecycle: you'll learn how to use [Kubeflow](https://www.kubeflow.org) and open source tools such as [Feast](https://github.com/feast-dev/feast) to build a workflow you can run on your laptop and adapt to your own projects.
 
 We'll walk through the entire ML lifecycle—from data preparation to live inference—leveraging the Kubeflow platform to create a cohesive, production-grade MLOps workflow.


### PR DESCRIPTION
The title got duplicated in the latest post.
This PR fixes it.

<img width="1010" height="527" alt="Screenshot 2025-07-18 at 10 41 33" src="https://github.com/user-attachments/assets/55ad3e6b-511d-40a4-88a9-512985432f49" />

cc @franciscojavierarceo 