### PR TITLE
Add Kale 2.0 release blog post

### DIFF
--- a/_posts/2026-05-06-kale-2.0-release.md
+++ b/_posts/2026-05-06-kale-2.0-release.md
@@ -1,0 +1,58 @@
+---
+toc: true
+layout: post
+comments: true
+title: "Kale 2.0: A new chapter for an old idea"
+hide: false
+categories: [kale, release]
+permalink: /kale-2.0-release/
+author: Stefano Fioravanzo
+---
+
+This is a post I'd long wished for, then lost hope for, then forgot about. Somehow, things started moving again. And here we are. Kale is officially part of the Kubeflow ecosystem, it's alive and growing, and now has a new release that will lay the foundation for a whole new chapter.
+
+Kale began as my graduate thesis in Data Science. It turned into a real product at Arrikto, a Greek startup that got swept away by the strong currents of the startup world. Kale wa then picked up by the community, and at some point started showing up in talks and tutorials I had nothing to do with. Then — like a lot of open source — it went quiet. For a few years I kept an eye on the inbox, answered the occasional question, and watched the repo slowly drift away from the world it was built for.
+
+With Kale 2.0 landing upstream, that quiet period is officially over.
+
+## A graduate project, finally home
+
+It took me a while to process that Kale now lives at `kubeflow/kale`. The repo, the working group, the Google Summer of Code 2025 collaboration that did the heavy lifting on the Kubeflow Pipelines (KFP) v2 backend migration — none of it is "mine" anymore in the way it used to be. And that is exactly what I hoped would happen.
+
+Seeing momentum return to a project that had been dormant for years means a lot to me. It tells me the original idea — giving data scientists a way to ship pipelines from inside their notebook — wasn't a side product of a specific company or moment in time. It was a real problem, and it still is.
+
+I'm fully aware that the project will take a path I don't get to fully chart anymore. New maintainers, new priorities, new opinions. That's how it should be, and I'm genuinely happy about it.
+
+## What's in 2.0
+
+The headline is full KFP v2 compatibility — the entire backend has been rewritten to compile against the v2 pipeline spec and to support the artifact-based data passing mechanism. Alongside that, the JupyterLab extension has been modernized and now runs on JupyterLab 4, and a handful of legacy pieces have been removed. 2.0 also brings loads of usability improvements, lots of modernizing refactors, a new sidebar "homepage", revamped examples, and a dedicated [documentation website](https://kale.kubeflow.org)! The full notes are on the [releases page](https://github.com/kubeflow/kale/releases).
+
+## Why Kale, still?
+
+This is the part I actually want to talk about.
+
+The world Kale was born into looked very different. In 2019, "abstract away the KFP SDK so data scientists don't have to write boilerplate" was a clear, useful goal on its own. In 2026, an AI assistant will happily write that boilerplate for you in seconds. So the obvious question is: what is Kale even for now?
+
+My answer is that Kale was never really about hiding KFP. It was about meeting users where they already work. That goal becomes *more* important in an AI-native world, not less.
+
+I see Kale today as the foundation for a low-code approach to Kubeflow, with two directions that matter to me.
+
+The first is synergy with the [Kubeflow SDK](https://sdk.kubeflow.org). The SDK is unifying how users interact with Kubeflow across CLI, API, and Python — Kale's job is to bring that same surface *inside the notebook*, so a data scientist's experience stays coherent whether they're in a terminal, a script, or a JupyterLab tab.
+
+The second is synergy with the JupyterLab community. The notebook itself is becoming a richer surface — real-time collaboration, [Jupyter AI](https://jupyter-ai.readthedocs.io/) for in-context AI assistance, and a steady push toward notebooks as a serious development environment. Kale plugs straight into that direction. A pipeline you can describe, refine with an AI assistant, and run on Kubeflow without leaving the notebook is a much more interesting product than "a UI for KFP."
+
+On top of that, we have more ideas than we can follow through on. We'll experiment with low-code, in-notebook interfaces for orchestrating multiple notebooks as part of the upcoming Google Summer of Code 2026 project.
+
+## Thank you
+
+To everyone in the ML Experience Working Group, to [Eder Ignatowicz](https://github.com/ederign) for co-leading the Kale focus with me, to [Amrit Kumar](https://github.com/Amrit27k) for his GSoC contributions, to [Andrey Velichkevich](https://github.com/andreyvelich) for the relentless operational support, and to the maintainers and reviewers who showed up for an old project that needed waking up — [Hannah Tosi](https://github.com/hmtosi), [Adam David Maly](https://github.com/ada333), [William Antônio Siqueira](https://github.com/jesuino), [Yashh](https://github.com/Ya-shh), [Naymul Islam](https://github.com/ai-naymul) and others! You all took something that had been quiet for years and gave it a second life inside the community it was always meant to live in.
+
+## Want to Contribute?
+
+- GitHub: [kubeflow/kale](https://github.com/kubeflow/kale)
+- Slack: [#kubeflow-ml-experience](https://kubeflow.slack.com/) on the Kubeflow workspace
+- Working group: ML Experience WG meetings — see the [Kubeflow community calendar](https://www.kubeflow.org/docs/about/community/)
+- Browse the [Kale page](https://www.kubeflow.org/docs/components/kale/overview/) in the Kubeflow website
+- Issues & feature requests: [github.com/kubeflow/kale/issues](https://github.com/kubeflow/kale/issues)
+
+— Stefano


### PR DESCRIPTION
Adding a personal piece announcing the release of Kale 2.0.

Keeping in draft until we can full consensus on the announcement strategy

cc @ederign 